### PR TITLE
Corrige indentação e intervalos da contagem

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -5,43 +5,21 @@ namespace regressiva
     class Program
     {
         static void Main(string[] args)
-        {Console.WriteLine("Preparar...");
+        {
+            
+            Console.WriteLine("Preparar...");
+            Console.WriteLine("Pressione ENTER para continuar");
+            Console.ReadLine();
+            Console.WriteLine();
+            
+            Console.WriteLine("Apontar...");
+            Console.WriteLine("Pressione ENTER para continuar");
+            Console.ReadLine();
+            Console.WriteLine();
 
-
-Console.WriteLine("Pressione ENTER para continuar");
-
-
-Console.ReadKey();
-
-
-Console.Write("\n");
-
-
-
-
-
-Console.WriteLine("Apontar...");
-
-
-Console.WriteLine("Pressione ENTER para continuar");
-
-
-Console.ReadKey();
-
-
-Console.Write("\n");
-
-
-
-
-
-Console.WriteLine("FOGO!");
-
-
-Console.WriteLine("Pressione ENTER para sair");
-
-
-Console.ReadKey();
+            Console.WriteLine("FOGO!");
+            Console.WriteLine("Pressione ENTER para sair");
+            Console.ReadLine();
     
         }
     }


### PR DESCRIPTION
Para obrigar o enter, deve-se utilizar o Console.ReadLine().
Com o Console.ReadKey(), qualquer tecla pressionada segue com a execução.

Console.WriteLine() e Console.Write("\n") se equivalem, porém, Console.WriteLine() deixa o código mais limpo.